### PR TITLE
Adapt to sidechain perturbation

### DIFF
--- a/conda_recipe/meta.yaml
+++ b/conda_recipe/meta.yaml
@@ -1,7 +1,7 @@
 # must do: conda-build -c conda-forge -c nostrumbiodiscovery -c rdkit -c carlesperez94 . 
 package:
   name: frag_pele
-  version: "2.2.0"
+  version: "2.3.1"
 
 about:
   home: https://github.com/carlesperez94/frag_pele

--- a/frag_pele/Analysis/compute_atom_atom_distance.py
+++ b/frag_pele/Analysis/compute_atom_atom_distance.py
@@ -1,0 +1,62 @@
+import glob
+import os
+import argparse
+import mdtraj as md
+import pandas as pd
+
+def parseArguments():
+    """
+        Parse the command-line options
+        :returns: str, int, int --  path to file to results folder,
+            index of the first atom,
+            index of the second atom
+    """
+    desc = "It includes the atom-atom distance of the specified ones to report files\n"
+    parser = argparse.ArgumentParser(description=desc)
+    required_named = parser.add_argument_group('required named arguments')
+    required_named.add_argument("sim_folder", type=str, help="Path to the simulation results.")
+
+    required_named.add_argument("-a1", type=int, help="Index of the first atom.")
+    required_named.add_argument("-a2", type=int, help="Index of the second atom.")
+    parser.add_argument("-t", "--traj", default="trajectory_",
+                        help="Trajectory file prefix.")
+    parser.add_argument("-r", "--rep", default="report_",
+                        help="Report file prefix.")
+    args = parser.parse_args()
+    return args.sim_folder, args.a1, args.a2, args.traj, args.rep
+
+
+def compute_atom_atom_dist(infile, atomnum1, atomnum2):
+    traj = md.load_pdb(infile)
+    name ="{}-{}".format(traj.topology.atom(atomnum1), traj.topology.atom(atomnum2))
+    return md.compute_distances(traj, [[atomnum1, atomnum2]]), name
+
+def compute_simulation_distance(sim_folder, atomnum1, atomnum2, traj_pref="trajectory_", report_pref="report_"):
+    trajectories = sorted(glob.glob("{}*".format(os.path.join(sim_folder, traj_pref))))
+    reports = sorted(glob.glob("{}*".format(os.path.join(sim_folder, report_pref))))
+    for report, trajectory in zip(reports, trajectories):
+        dist, colname = compute_atom_atom_dist(trajectory, atomnum1, atomnum2)
+        new_lines = []
+        with open(report) as rep:
+            rep_lines = rep.readlines()
+            rep_lines = [x.strip("\n") for x in rep_lines]
+            for ind, line in enumerate(rep_lines):
+                new_content = list(line.split("    "))
+                new_content = new_content[:-1]
+                if ind == 0:
+                    new_content.append(colname)
+                else:
+                    value = "{:.3f}".format(dist[ind-1][0]*10)
+                    new_content.append(value)
+                new_line = "    ".join(new_content)
+                new_lines.append(new_line)
+        new_report = "\n".join(new_lines)
+        new_rep_name = report.split("/")
+        new_rep_name[-1] = "dist" + new_rep_name[-1]
+        new_rep_name = "/".join(new_rep_name)
+        with open(new_rep_name, "w") as out:
+            out.write(new_report)
+
+if __name__ == '__main__':
+    sim_fold, atom1, atom2, traj, report = parseArguments()
+    compute_simulation_distance(sim_fold, atom1, atom2, traj, report)

--- a/frag_pele/Covalent/correct_rotamer_library.py
+++ b/frag_pele/Covalent/correct_rotamer_library.py
@@ -1,0 +1,50 @@
+class RotamerModifier():
+    def __init__(self, input_file):
+        self.input_file = input_file
+        self.content = None
+        self.lines = []
+        self.lines_splitted = []
+        self.read_file()
+        self.read_rotamers()
+
+    def read_file(self):
+        with open(self.input_file) as inp:
+            self.lines = inp.readlines()
+   
+    def read_rotamers(self):
+        for line in self.lines:
+            split = line.split(" ")
+            self.lines_splitted.append(split)
+
+    def find_rotamer(self, atom1, atom2):
+        for n, line in enumerate(self.lines_splitted):
+            if line[3] == "sidelib":
+                if (line[5] == atom1 and line[6] == atom2) or \
+                   (line[5] == atom2 and line[6] == atom1):
+                    return n # The index of the list
+
+    def delete_rotamer(self, atom1, atom2):
+        index_to_del = self.find_rotamer(atom1, atom2)
+        print("Rotamer '{}' will be deleted".format(" ".join(self.lines_splitted[index_to_del]).strip("\n")))
+        del self.lines_splitted[index_to_del]
+        self.update_content()
+
+    def update_content(self):
+        self.lines = []
+        for line in self.lines_splitted:
+            self.lines.append(" ".join(line))
+        self.content = "".join(self.lines)
+
+    def overwrite_file(self):
+        with open(self.input_file, "w") as out:
+            out.write(self.content)
+
+def delete_atoms_from_rot_lib(input_file, list_of_atom_pairs):
+    rot = RotamerModifier(input_file)
+    for pair in list_of_atom_pairs:
+        rot.delete_rotamer(pair[0], pair[1])
+    rot.overwrite_file()
+
+
+list_at = [("_CA_", "__C_"), ("__N_", "_CA_")]
+delete_atoms_from_rot_lib("GRW.rot.assign", list_at)

--- a/frag_pele/Covalent/correct_rotamer_library.py
+++ b/frag_pele/Covalent/correct_rotamer_library.py
@@ -45,6 +45,3 @@ def delete_atoms_from_rot_lib(input_file, list_of_atom_pairs):
         rot.delete_rotamer(pair[0], pair[1])
     rot.overwrite_file()
 
-
-list_at = [("_CA_", "__C_"), ("__N_", "_CA_")]
-delete_atoms_from_rot_lib("GRW.rot.assign", list_at)

--- a/frag_pele/Growing/simulations_linker.py
+++ b/frag_pele/Growing/simulations_linker.py
@@ -73,7 +73,10 @@ def control_file_modifier(control_template, pdb, license, working_dir, overlap=0
     tp.TemplateBuilder(os.path.join(working_dir, control_template), keywords)
     # Make a copy in the control files folder
     simulation_file = os.path.join(ctrl_fold_name, "{}_{}".format(step, control_template))
-    shutil.copyfile(os.path.join(working_dir, control_template), simulation_file)
+    print(simulation_file)
+    original_control = os.path.join(working_dir, control_template)
+    print(original_control)
+    shutil.copyfile(original_control, simulation_file)
     logger.info("{}_{} has been created successfully!".format(step, control_template))
 
     return simulation_file

--- a/frag_pele/Helpers/check_constants.py
+++ b/frag_pele/Helpers/check_constants.py
@@ -7,9 +7,11 @@ def check():
         raise OSError("Schrodinger path {} not found. Change the harcoded path under frag_pele/constants.py".format(cs.SCHRODINGER_PY_PATH))
     if not os.path.exists(cs.PATH_TO_PELE):
         raise OSError("Pele path {} not found. Change the harcoded path under frag_pele/constants.py".format(cs.PATH_TO_PELE))
-    elif not os.path.exists(cs.PATH_TO_PELE_DATA):
-        raise OSError("Pele data path {} not found. Change the harcoded path under frag_pele/constants.py".format(cs.PATH_TO_PELE_DATA))
-    elif not os.path.exists(cs.PATH_TO_PELE_DOCUMENTS):
-        raise OSError("Pele documents path {} not found. Change the harcoded path under frag_pele/constants.py".format(cs.PATH_TO_PELE_DOCUMENTS))
+    elif cs.PATH_TO_PELE_DATA != None:
+        if not os.path.exists(cs.PATH_TO_PELE_DATA):
+            raise OSError("Pele data path {} not found. Change the harcoded path under frag_pele/constants.py".format(cs.PATH_TO_PELE_DATA))
+    elif cs.PATH_TO_PELE_DOCUMENTS != None:
+        if not os.path.exists(cs.PATH_TO_PELE_DOCUMENTS):
+            raise OSError("Pele documents path {} not found. Change the harcoded path under frag_pele/constants.py".format(cs.PATH_TO_PELE_DOCUMENTS))
     elif not os.path.exists(cs.PATH_TO_LICENSE):
         raise OSError("Pele license path {} not found. Change the harcoded path under frag_pele/constants.py".format(cs.PATH_TO_LICENSE))

--- a/frag_pele/Templates/control_covalent.conf
+++ b/frag_pele/Templates/control_covalent.conf
@@ -29,6 +29,16 @@
          },
 
 $CONSTRAINTS
+         "SideChainPerturbation":{                                        
+                   "sideChainsToPerturb": { "links": {"ids": ["$RESCHAIN:$RESNUM"] } }
+                      "parameters":{                                      
+                             "overlapFactor": 0.5,                        
+                             "numberOfStericTrials": 50,                  
+                             "numberOfTrials": 15,                        
+                             "gridResolution": 10,                        
+                             "atLeastOneSelectedTrial": true              
+                       }                                                  
+                  },
          "ANM" : {
             "algorithm" : "ALPHACARBONS",
             "ANMMinimizer" : {
@@ -58,8 +68,7 @@ $CONSTRAINTS
          },
          "SideChainPrediction" : {
             "algorithm" : "zhexin",
-            "parameters" : { "discardHighEnergySolutions" : false, "resolution": 10, "randomize" : false, "numberOfIterations": 100, "minimalOverlapFactor" : $OVERLAP },
-         "selectionToInclude": { "links": {"ids": ["$RESCHAIN:$RESNUM"] } }
+            "parameters" : { "discardHighEnergySolutions" : false, "resolution": 10, "randomize" : false, "numberOfIterations": 5, "minimalOverlapFactor" : $OVERLAP }
          },
          "Minimizer" : {
             "algorithm" : "TruncatedNewton",

--- a/frag_pele/Templates/control_covalent.conf
+++ b/frag_pele/Templates/control_covalent.conf
@@ -30,7 +30,7 @@
 
 $CONSTRAINTS
          "SideChainPerturbation":{                                        
-                   "sideChainsToPerturb": { "links": {"ids": ["$RESCHAIN:$RESNUM"] } }
+                   "sideChainsToPerturb": { "links": {"ids": ["$RESCHAIN:$RESNUM"] } },
                       "parameters":{                                      
                              "overlapFactor": 0.5,                        
                              "numberOfStericTrials": 50,                  

--- a/frag_pele/constants.py
+++ b/frag_pele/constants.py
@@ -15,8 +15,8 @@ print(machine)
 # Paths definitions (IMPORTANT!)
 if "bsc.mn" in machine:
     # PELE parameters
-    PATH_TO_PELE = "/gpfs/projects/bsc72/PELE++/mniv/V1.6.1/bin/PELE-1.6.1_mpi"
-    PATH_TO_PELE_DATA = None
+    PATH_TO_PELE = "/gpfs/projects/bsc72/PELE++/mniv/V1.6.2-SideChainPert/bin/PELE-1.6.2_mpi"
+    PATH_TO_PELE_DATA = "/gpfs/projects/bsc72/PELE++/mniv/V1.6.2-SideChainPert/Data"
     PATH_TO_PELE_DOCUMENTS = None # Data and documents is added automatically from PELE >= 1.6
     PATH_TO_LICENSE = "/gpfs/projects/bsc72/PELE++/license"
     # PlopRotTemp parameters

--- a/frag_pele/constants.py
+++ b/frag_pele/constants.py
@@ -16,8 +16,8 @@ print(machine)
 if "bsc.mn" in machine:
     # PELE parameters
     PATH_TO_PELE = "/gpfs/projects/bsc72/PELE++/mniv/V1.6.1/bin/PELE-1.6.1_mpi"
-    PATH_TO_PELE_DATA = "/gpfs/projects/bsc72/PELE++/mniv/V1.6.1/Data"
-    PATH_TO_PELE_DOCUMENTS = "/gpfs/projects/bsc72/PELE++/mniv/V1.6.1/Documents"
+    PATH_TO_PELE_DATA = None
+    PATH_TO_PELE_DOCUMENTS = None # Data and documents is added automatically from PELE >= 1.6
     PATH_TO_LICENSE = "/gpfs/projects/bsc72/PELE++/license"
     # PlopRotTemp parameters
     SCHRODINGER_PY_PATH = "/gpfs/projects/bsc72/SCHRODINGER_ACADEMIC/utilities/python"
@@ -32,11 +32,11 @@ elif "bsccv" in machine:
     ENV_PYTHON = "/data2/bsc72/SCHRODINGER_ACADEMIC/internal/lib/python2.7/site-packages/"
 else:
     # PELE parameters
-    PATH_TO_PELE = "/home/carlespl/repos/PELE-repo/build/PELE-1.5_mpi"
-    PATH_TO_PELE_DATA = "/home/carlespl/repos/PELE-repo/Data"
-    PATH_TO_PELE_DOCUMENTS = "/home/carlespl/repos/PELE-repo/Documents"
-    PATH_TO_LICENSE = "/home/carlespl/repos/PELE-repo/licenses"
-    SCHRODINGER_PY_PATH = "/home/carlespl/schrodinger2019-2/run"
+    PATH_TO_PELE = "/home/user/pelepath/PELE_mpi"
+    PATH_TO_PELE_DATA = None
+    PATH_TO_PELE_DOCUMENTS = None
+    PATH_TO_LICENSE = "/home/user/pelepath/licenses"
+    SCHRODINGER_PY_PATH = "/home/user/schrodingerVVVV-VV/run"
     ENV_PYTHON = ""
 
 # FragPELE configuration

--- a/frag_pele/main.py
+++ b/frag_pele/main.py
@@ -373,8 +373,10 @@ def grow_fragment(complex_pdb, fragment_pdb, core_atom, fragment_atom, iteration
     # Creating constraints
     const = "\n".join(constraints.retrieve_constraints(complex_pdb, {}, {}, 5, 5, 10))
     # Creating symbolic links
-    helpers.create_symlinks(data, os.path.join(working_dir, 'Data'))
-    helpers.create_symlinks(documents, os.path.join(working_dir, 'Documents'))
+    if data:
+        helpers.create_symlinks(data, os.path.join(working_dir, 'Data'))
+    if documents:
+        helpers.create_symlinks(documents, os.path.join(working_dir, 'Documents'))
     #  ---------------------------------------Pre-growing part - PREPARATION -------------------------------------------
     if cov_res:
         new_chain, resnum_core = complex_to_prody.read_residue_string(cov_res)

--- a/frag_pele/main.py
+++ b/frag_pele/main.py
@@ -552,6 +552,7 @@ def grow_fragment(complex_pdb, fragment_pdb, core_atom, fragment_atom, iteration
         # ------SIMULATION PART------
         # Change directory to the working one
         os.chdir(working_dir)
+        print(working_dir)
         if debug:
             return 
         else:
@@ -633,6 +634,7 @@ def grow_fragment(complex_pdb, fragment_pdb, core_atom, fragment_atom, iteration
     if not (restart and os.path.exists("top_result")):
         logger.info(".....STARTING EQUILIBRATION.....")
         simulations_linker.simulation_runner(pele_dir, simulation_file, cpus)
+        print(simulation_file)
     os.chdir(curr_dir)
     equilibration_path = os.path.join(working_dir, "sampling_result")
     # SELECTION OF BEST STRUCTURES

--- a/frag_pele/main.py
+++ b/frag_pele/main.py
@@ -16,7 +16,7 @@ from frag_pele.Helpers import clusterizer, checker, folder_handler, runner, cons
 from frag_pele.Helpers import helpers, correct_fragment_names, center_of_mass, plop_rot_temp
 from frag_pele.Growing import template_fragmenter, simulations_linker
 from frag_pele.Growing import add_fragment_from_pdbs, bestStructs
-from frag_pele.Covalent import correct_pdb_to_covalent_res, correct_template_of_backbone_res
+from frag_pele.Covalent import correct_pdb_to_covalent_res, correct_template_of_backbone_res, correct_rotamer_library
 from frag_pele.Analysis import analyser
 from frag_pele.Banner import Detector as dt
 from frag_pele import serie_handler
@@ -422,11 +422,17 @@ def grow_fragment(complex_pdb, fragment_pdb, core_atom, fragment_atom, iteration
                     os.path.join(path_to_templates_generated, template_resnames[0].lower()))
             correct_template_of_backbone_res.correct_template(os.path.join(path_to_templates_generated, 
                                                           template_resnames[0].lower()), working_dir)
+        # Correcting templates
         shutil.move(os.path.join(path_to_templates_generated, template_resnames[1].lower()+"z"),
                     os.path.join(path_to_templates_generated, template_resnames[1].lower()))
         correct_pdb_to_covalent_res.correct_pdb(pdb_initialize, new_chain, resnum_core, template_resnames[1])
         correct_template_of_backbone_res.correct_template(os.path.join(path_to_templates_generated, 
                                                           template_resnames[1].lower()), working_dir)
+        # Correcting rotamer libraries
+        backbone_bonds = [("_CA_", "__C_"), ("__N_", "_CA_")]
+        rot_lib_filename = os.path.join(working_dir, "DataLocal/LigandRotamerLibs/{}.rot.assign".format(template_resnames[1]))
+        print(rot_lib_filename)
+        correct_rotamer_library.delete_atoms_from_rot_lib(rot_lib_filename, backbone_bonds)
 
     # Get template filenames
     if cov_res:

--- a/tests/run_pytest
+++ b/tests/run_pytest
@@ -10,7 +10,7 @@ module purge
 unset PYTHONPATH
 export PELE="/gpfs/projects/bsc72/PELE++/mniv/V1.6/"
 export SCHRODINGER="/gpfs/projects/bsc72/SCHRODINGER_ACADEMIC"
-export PYTHONPATH="/gpfs/projects/bsc72/LibPrep/v1.1/lib_prep:/gpfs/projects/bsc72/FragPELE/FragPELE2.3.0_testing/frag_pele"
+export PYTHONPATH="/gpfs/projects/bsc72/LibPrep/v1.1.1/lib_prep:/gpfs/projects/bsc72/FragPELE/FragPELE2.3.1_testing/frag_pele"
 export PATH=/home/bsc72/bsc72292/.conda/envs/frag23/bin:$PATH
 
 module load intel mkl impi gcc # 2> /dev/null

--- a/tests/serie_res.conf
+++ b/tests/serie_res.conf
@@ -1,2 +1,2 @@
-frag_res.pdb	SG	C4
+carbonyl.pdb	SG	C1
 	

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -44,9 +44,9 @@ def test_cov_aa():
     for output in outputs:
         if os.path.exists(output):
             shutil.rmtree(output)
-    mn.main("receptor_145_cys.pdb", "serie_res.conf", cpus=4, iterations=1, steps=1, pele_eq_steps=1, test=True, cov_res="A:145",
+    mn.main("receptor_145_cys.pdb", "serie_res.conf", cpus=4, iterations=1, steps=2, pele_eq_steps=1, test=True, cov_res="A:145",
             criteria="LocalNonBondingEnergy")
-    assert glob.glob("receptor_145_cys_frag_resSGC4/top_result/*Local*.pdb")
+    assert glob.glob("receptor_145_cys_carbonylSGC1/top_result/*Local*.pdb")
 
 def test_cov_mod():
     outputs = ["cov_scaffold_10C5C1"]


### PR DESCRIPTION
FragPELE code and templates have been adapted to the new feature of PELE: SideChainPerturbation.
It allows us to grow any fragment onto a residue (modified or not) and perturb it along with the simulation procedure.

Highlights:
- Backbone bonds are removed from the rotamer library file of the new residue in covalent growing procedures.
- Documents default set to None, as PELE can automatically create this symbolic link in PELE >= 1.6
- Data default has been updated, and it is used to get data from amino acid templates when growing something onto them.
- The covalent control file has been modified to the new version of PELE (1.6.2 - SideChainPerturb)