### PR TITLE
V3.1

### DIFF
--- a/frag_pele/Growing/template_fragmenter.py
+++ b/frag_pele/Growing/template_fragmenter.py
@@ -998,6 +998,9 @@ def reduce_fragment_parameters_originaly(template_grow, template_core, lambda_to
 def modify_core_parameters_linearly(template_grow, lambda_to_reduce, template_core, exp_charges=False, 
                                     null_charges=False):
     reductor = ReduceLinearly(template_grow, lambda_to_reduce, template_core)
+    if exp_charges:
+        reductor_exp = ReduceExponentially(template_grow, lambda_to_reduce, template_core)
+        exp_charges = reductor_exp.reduce_value_from_diference
     reductor.modify_core_nbond_params(reductor.reduce_value_from_diference, 
                                       exp_charges, null_charges)
     reductor.modify_core_bond_eq_dist(reductor.reduce_value_from_diference)

--- a/frag_pele/Growing/template_fragmenter.py
+++ b/frag_pele/Growing/template_fragmenter.py
@@ -998,13 +998,8 @@ def reduce_fragment_parameters_originaly(template_grow, template_core, lambda_to
 def modify_core_parameters_linearly(template_grow, lambda_to_reduce, template_core, exp_charges=False, 
                                     null_charges=False):
     reductor = ReduceLinearly(template_grow, lambda_to_reduce, template_core)
-    if exp_charges:
-        reductor_exp = ReduceExponentially(template_grow, lambda_to_reduce, template_core)
-        reductor.modify_core_nbond_params(reductor.reduce_value_from_diference, 
-                                          reductor_exp.reduce_value_from_diference,
-                                          null_charges)
-    else:
-        reductor.modify_core_nbond_params(reductor.reduce_value_from_diference, None)
+    reductor.modify_core_nbond_params(reductor.reduce_value_from_diference, 
+                                      exp_charges, null_charges)
     reductor.modify_core_bond_eq_dist(reductor.reduce_value_from_diference)
     reductor.modify_core_theta(reductor.reduce_value_from_diference)
     reductor.modify_core_phis(reductor.reduce_value_from_diference)
@@ -1053,7 +1048,6 @@ def main(template_initial_path, template_grown_path, step, total_steps, hydrogen
     set_fragment_bonds(list_of_fragment_bonds=fragment_bonds)
     set_linker_bond(templ_grw)
     if growing_mode == "SoftcoreLike":
-        modify_core_parameters_linearly(templ_grw, lambda_to_reduce, templ_ini, exp_charges=True)
         modify_core_parameters_linearly(templ_grw, lambda_to_reduce, templ_ini, exp_charges=True,
                                         null_charges=null_charges)
         reduce_fragment_parameters_linearly(templ_grw, lambda_to_reduce, exp_charges=True, 

--- a/frag_pele/Growing/template_fragmenter.py
+++ b/frag_pele/Growing/template_fragmenter.py
@@ -714,7 +714,7 @@ class ReduceProperty:
                    result = function(atom_c.charge, atom_g.charge)
                    self.template.list_of_atoms[index_g].charge = result
 
-    def modify_core_nbond_params(self, function, exp_function=None):
+    def modify_core_nbond_params(self, function, exp_function=None, keep_charges=False):
         atoms_grw = self.template.get_list_of_core_atoms()
         atoms_ini = self.template_core.get_list_of_core_atoms()
         for atom_grow in atoms_grw:
@@ -726,7 +726,9 @@ class ReduceProperty:
                    self.template.list_of_atoms[index_g].epsilon = result
                    result = function(atom_c.sigma, atom_g.sigma)
                    self.template.list_of_atoms[index_g].sigma = result
-                   if exp_function:
+                   if keep_charges:
+                       result = atom_c.charge
+                   elif exp_function:
                        result = exp_function(atom_c.charge, atom_g.charge)
                    else:
                        result = function(atom_c.charge, atom_g.charge)
@@ -999,7 +1001,8 @@ def modify_core_parameters_linearly(template_grow, lambda_to_reduce, template_co
     if exp_charges:
         reductor_exp = ReduceExponentially(template_grow, lambda_to_reduce, template_core)
         reductor.modify_core_nbond_params(reductor.reduce_value_from_diference, 
-                                          reductor_exp.reduce_value_from_diference)
+                                          reductor_exp.reduce_value_from_diference,
+                                          null_charges)
     else:
         reductor.modify_core_nbond_params(reductor.reduce_value_from_diference, None)
     reductor.modify_core_bond_eq_dist(reductor.reduce_value_from_diference)
@@ -1051,8 +1054,11 @@ def main(template_initial_path, template_grown_path, step, total_steps, hydrogen
     set_linker_bond(templ_grw)
     if growing_mode == "SoftcoreLike":
         modify_core_parameters_linearly(templ_grw, lambda_to_reduce, templ_ini, exp_charges=True)
+        modify_core_parameters_linearly(templ_grw, lambda_to_reduce, templ_ini, exp_charges=True,
+                                        null_charges=null_charges)
         reduce_fragment_parameters_linearly(templ_grw, lambda_to_reduce, exp_charges=True, 
-                                            null_charges=True)
+                                            null_charges=null_charges)
+            
         modify_linkers_parameters_linearly(templ_grw, lambda_to_reduce, templ_ini, hydrogen_to_replace)
     elif growing_mode == "AllLinear":
         modify_core_parameters_linearly(templ_grw, lambda_to_reduce, templ_ini, exp_charges=False)

--- a/frag_pele/Helpers/create_templates.py
+++ b/frag_pele/Helpers/create_templates.py
@@ -25,7 +25,7 @@ def create_template_path(path, name, forcefield='OPLS2005', protein=False, templ
                             templ_string, name.lower())
     if forcefield == 'OFF' and protein:
         path = os.path.join(path, 
-                            'DataLocal/Templates/OFF/Protein',
+                            'DataLocal/Templates/OpenFF/Protein',
                             templ_string, aminoacid.lower())
     if forcefield == 'OPLS2005' and not protein:
         path = os.path.join(path,         
@@ -33,7 +33,7 @@ def create_template_path(path, name, forcefield='OPLS2005', protein=False, templ
                             templ_string, name.lower()+"z")
     if forcefield == 'OFF' and not protein:
         path = os.path.join(path,
-                            'DataLocal/Templates/OFF/Parsley',
+                            'DataLocal/Templates/OpenFF/Parsley',
                             templ_string, name.lower()+"z")
     return path
 
@@ -85,6 +85,12 @@ def get_template_and_rot(pdb, forcefield='OPLS2005', template_name='grw', aminoa
         ff = OpenForceField('openff_unconstrained-1.2.0.offxml')
     parameters = ff.parameterize(m)
     topology = Topology(m, parameters)
+    if forcefield == 'OFF': # Not tested yet
+        from peleffy.solvent import OBC2
+        solvent = OBC2(topology)
+        solvent.to_file(os.path.join(outdir,
+                                     "DataLocal/OBC/ligandParams.txt"))
+
     impact = Impact(topology)
     impact.to_file(template_path) 
     print("Template in {}.".format(template_path))
@@ -97,7 +103,7 @@ def get_template_and_rot(pdb, forcefield='OPLS2005', template_name='grw', aminoa
 def add_off_waters_to_datalocal(outdir):
     path = os.path.dirname(frag_pele.__file__)
     shutil.copy(os.path.join(path, "Templates/OFF/hohz"),
-                os.path.join(outdir, "DataLocal/Templates/OFF/Parsley/hohz"))
+                os.path.join(outdir, "DataLocal/Templates/OpenFF/Parsley/hohz"))
  
 def get_datalocal(pdb, outdir='.', forcefield='OPLS2005', template_name='grw', aminoacid=False, rot_res=30,
                   constrainted_atoms=None, aminoacid_type=None, sch_path=c.SCHRODINGER):
@@ -106,5 +112,5 @@ def get_datalocal(pdb, outdir='.', forcefield='OPLS2005', template_name='grw', a
                          aminoacid=aminoacid, outdir=outdir, rot_res=rot_res,
                          contrained_atoms=constrainted_atoms, aminoacid_type=aminoacid_type,
                          sch_path=sch_path)
-    if forcefield == 'OFF':
-        add_off_waters_to_datalocal(outdir)
+#    if forcefield == 'OFF':
+#        add_off_waters_to_datalocal(outdir)

--- a/frag_pele/Helpers/folder_handler.py
+++ b/frag_pele/Helpers/folder_handler.py
@@ -17,17 +17,18 @@ def check_and_create_DataLocal(working_dir):
     # Get current path
     check_and_create_folder((os.path.join(working_dir, "DataLocal")))
     check_and_create_folder((os.path.join(working_dir, "DataLocal/LigandRotamerLibs")))
+    check_and_create_folder((os.path.join(working_dir, "DataLocal/OBC")))
     check_and_create_folder((os.path.join(working_dir, "DataLocal/Templates")))
     check_and_create_folder((os.path.join(working_dir, "DataLocal/Templates/OPLS2005")))
     check_and_create_folder((os.path.join(working_dir, "DataLocal/Templates/OPLS2005/HeteroAtoms")))
     check_and_create_folder((os.path.join(working_dir, "DataLocal/Templates/OPLS2005/HeteroAtoms", "templates_generated")))
     check_and_create_folder((os.path.join(working_dir, "DataLocal/Templates/OPLS2005/Protein")))
     check_and_create_folder((os.path.join(working_dir, "DataLocal/Templates/OPLS2005/Protein", "templates_generated")))
-    check_and_create_folder((os.path.join(working_dir, "DataLocal/Templates/OFF")))
-    check_and_create_folder((os.path.join(working_dir, "DataLocal/Templates/OFF/Protein")))
-    check_and_create_folder((os.path.join(working_dir, "DataLocal/Templates/OFF/Protein", "templates_generated")))
-    check_and_create_folder((os.path.join(working_dir, "DataLocal/Templates/OFF/Parsley")))
-    check_and_create_folder((os.path.join(working_dir, "DataLocal/Templates/OFF/Parsley", "templates_generated")))
+    check_and_create_folder((os.path.join(working_dir, "DataLocal/Templates/OpenFF")))
+    check_and_create_folder((os.path.join(working_dir, "DataLocal/Templates/OpenFF/Protein")))
+    check_and_create_folder((os.path.join(working_dir, "DataLocal/Templates/OpenFF/Protein", "templates_generated")))
+    check_and_create_folder((os.path.join(working_dir, "DataLocal/Templates/OpenFF/Parsley")))
+    check_and_create_folder((os.path.join(working_dir, "DataLocal/Templates/OpenFF/Parsley", "templates_generated")))
  
 
 

--- a/frag_pele/Templates/control_covalent.conf
+++ b/frag_pele/Templates/control_covalent.conf
@@ -4,7 +4,7 @@
   "verboseMode": false, 
   "Initialization" : {
      "allowMissingTerminals" :true,
-     "ForceField" : "$FF",
+     "ForceField" : "OPLS2005",
      "MultipleComplex" : [ $PDB ],
      "Solvent" : { "ionicStrength" : 0.15, "solventType" : "VDGBNP", "useDebyeLength" : true }
    },

--- a/frag_pele/Templates/control_covalent.conf
+++ b/frag_pele/Templates/control_covalent.conf
@@ -34,9 +34,7 @@ $CONSTRAINTS
                    "sideChainsToPerturb": { "links": {"ids": ["$RESCHAIN:$RESNUM"] } },
                       "parameters":{                                      
                              "overlapFactor": $OVERLAP,                        
-                             "numberOfStericTrials": 20,                  
                              "numberOfTrials": 10,                        
-                             "gridResolution": 10,                        
                              "atLeastOneSelectedTrial": true,
                              "maxTrialsForAtLeastOne": 50,
                              "refinementAngle": 10              

--- a/frag_pele/Templates/control_off.conf
+++ b/frag_pele/Templates/control_off.conf
@@ -1,0 +1,113 @@
+{
+  "licenseDirectoryPath": "$LICENSE",
+  "simulationLogPath" : "$RESULTS_PATH/logFile.txt", 
+  "Initialization" : {
+     "allowMissingTerminals" :true,
+     "ForceField" : "OpenFF-OPLS2005",
+     "MultipleComplex" : [ $PDB ],
+     "Solvent" : { "ionicStrength" : 0.15, "solventType" : "OBC", "useDebyeLength" : true }
+   },
+   "commands" : [
+      {
+         "commandType" : "peleSimulation",
+         "RandomGenerator" : { "seed" : $SEED },
+         "selectionToPerturb" : { "chains" : { "names" : [ "$CHAIN" ] } },
+         "PELE_Output" : {
+            "savingFrequencyForAcceptedSteps" : 1,
+            "savingMode" : "savingTrajectory",
+            "reportPath" : "$RESULTS_PATH/report",
+            "trajectoryPath" : "$RESULTS_PATH/trajectory.pdb"
+	  },
+         "PELE_Parameters" : {
+                "anmFrequency" : 2,
+                "sideChainPredictionFrequency" : 1,
+                "minimizationFrequency" : 1,
+                "sideChainPredictionRegionRadius" : 6,
+                "perturbationCOMConstraintConstant" : 1.0,
+                "activateProximityDetection": true,
+                "temperature": $TEMPERATURE,
+                "numberOfPeleSteps": $STEPS
+         },
+
+$CONSTRAINTS
+          "Perturbation": {
+               "Box" : {
+                   "radius" : $RADIUS,
+                   "fixedCenter": $CENTER,
+                   "type" : "sphericalBox"
+                },
+                "perturbationType":"naive",
+                "translationDirection": "steered",
+                "rotationAngles": "nonCoupled",
+                "parameters": {
+                    "numberOfStericTrials": 100,
+                    "steeringUpdateFrequency": $STEERING,
+                    "numberOfTrials" : 10,
+                    "overlapFactor": $OVERLAP
+                }
+            },
+         "ANM" : {
+            "algorithm" : "ALPHACARBONS",
+            "ANMMinimizer" : {
+               "algorithm" : "TruncatedNewton",
+               "parameters" : {
+                  "MaximumMinimizationIterations" : 1,
+                  "MaximumNewtonIterations" : 20,
+                  "MinimumRMS" : 0.25,
+                  "alphaUpdated" : false,
+                  "nonBondingListUpdatedEachMinStep" : false
+               }
+            },
+
+            "options" : {
+               "directionGeneration" : "random",
+               "modesMixingOption" : "mixMainModeWithOthersModes",
+               "pickingCase" : "RANDOM_MODE"
+            },
+            "parameters" : {
+               "displacementFactor" : 0.75,
+               "eigenUpdateFrequency" : 1000000,
+               "mainModeWeightForMixModes" : 0.75,
+               "modesChangeFrequency" : 4,
+               "relaxationSpringConstant" : 0.5,
+               "numberOfModes": 6
+            }
+         },
+         "SideChainPrediction" : {
+            "algorithm" : "zhexin",
+            "parameters" : { "discardHighEnergySolutions" : false, "resolution": 10, "randomize" : false, "numberOfIterations": 10, "minimalOverlapFactor" : $OVERLAP }
+         },
+         "Minimizer" : {
+            "algorithm" : "TruncatedNewton",
+            "parameters" : { "MinimumRMS" : $MIN_RMS, "alphaUpdated" : false, "nonBondingListUpdatedEachMinStep" : false }
+         },
+         "PeleTasks" : [
+            {
+               "metrics" : [
+                     { "type" : "bindingEnergy",
+                	"boundPartSelection": {"chains": {"names": ["$CHAIN"]}}
+		     },
+                     { "type": "sasa",
+                         "tag": "sasaLig",
+                         "selection": { "chains": { "names": ["$CHAIN"] } }
+                     },
+                     { "tag" : "rand", "type" : "random" },
+                     { "tag" : "rand1", "type" : "random" }
+                 ],
+
+                 "parametersChanges" : [
+                     { "ifAnyIsTrue": [ "rand >= 0.5" ],
+                         "doThesechanges": { "Perturbation::parameters": { "rotationScalingFactor": $ROTATION_HIGH } },
+                         "otherwise": { "Perturbation::parameters": { "rotationScalingFactor": $ROTATION_LOW } }
+                     },
+                     { "ifAnyIsTrue": [ "rand1 <= 0.5 " ],
+                         "doThesechanges": { "Perturbation::parameters": { "translationRange": $TRANSLATION_LOW } },
+                         "otherwise": { "Perturbation::parameters": { "translationRange": $TRANSLATION_HIGH } }
+                     }
+                  ]
+         }
+    ]
+  }
+ ]
+}
+

--- a/frag_pele/Templates/control_template.conf
+++ b/frag_pele/Templates/control_template.conf
@@ -3,7 +3,7 @@
   "simulationLogPath" : "$RESULTS_PATH/logFile.txt", 
   "Initialization" : {
      "allowMissingTerminals" :true,
-     "ForceField" : "$FF",
+     "ForceField" : "OPLS2005",
      "MultipleComplex" : [ $PDB ],
      "Solvent" : { "ionicStrength" : 0.15, "solventType" : "VDGBNP", "useDebyeLength" : true }
    },

--- a/frag_pele/constants.py
+++ b/frag_pele/constants.py
@@ -15,8 +15,8 @@ print(machine)
 # Paths definitions (IMPORTANT!)
 if "bsc.mn" in machine:
     # PELE parameters
-    PATH_TO_PELE = "/gpfs/projects/bsc72/PELE++/mniv/V1.6.2-SideChainPert_4/bin/PELE-1.6.2_mpi"
-    PATH_TO_PELE_DATA = "/gpfs/projects/bsc72/PELE++/mniv/V1.6.2-SideChainPert_4/Data"
+    PATH_TO_PELE = "/gpfs/projects/bsc72/PELE++/mniv/V1.7.1/bin/PELE-1.7.1_mpi"
+    PATH_TO_PELE_DATA = "/gpfs/projects/bsc72/PELE++/mniv/V1.7.1/Data"
     PATH_TO_PELE_DOCUMENTS = None # Data and documents is added automatically from PELE >= 1.6
     PATH_TO_LICENSE = "/gpfs/projects/bsc72/PELE++/license"
     # PlopRotTemp parameters

--- a/frag_pele/main.py
+++ b/frag_pele/main.py
@@ -412,8 +412,8 @@ def grow_fragment(complex_pdb, fragment_pdb, core_atom, fragment_atom, iteration
     pdbout_folder = os.path.join(working_dir, pdbout)
     if force_field == 'OFF':
         path_to_templates_generated = os.path.join(working_dir,
-                                                   "DataLocal/Templates/OFF/Parsley/templates_generated".format(force_field))
-        path_to_templates = os.path.join(working_dir, "DataLocal/Templates/OFF/Parsley".format(force_field))
+                                                   "DataLocal/Templates/OpenFF/Parsley/templates_generated".format(force_field))
+        path_to_templates = os.path.join(working_dir, "DataLocal/Templates/OpenFF/Parsley".format(force_field))
     elif force_field == 'OPLS2005':
         path_to_templates_generated = os.path.join(working_dir,
                                                    "DataLocal/Templates/OPLS2005/HeteroAtoms/templates_generated".format(force_field))
@@ -497,9 +497,9 @@ def grow_fragment(complex_pdb, fragment_pdb, core_atom, fragment_atom, iteration
     # Get template filenames
     if cov_res:
         template_initial, template_final = [resname.lower() for resname in template_resnames]
-        path_to_templates = os.path.join(working_dir, "DataLocal/Templates/{}/Protein".format(force_field))
+        path_to_templates = os.path.join(working_dir, "DataLocal/Templates/OPLS2005/Protein".format(force_field))
         path_to_templates_generated = os.path.join(working_dir,
-                                                   "DataLocal/Templates/{}/Protein/templates_generated".format(force_field))
+                                                   "DataLocal/Templates/OPLS2005/Protein/templates_generated".format(force_field))
     else:
         template_initial, template_final = ["{}z".format(resname.lower()) for resname in template_resnames]
     if only_prepare:
@@ -542,6 +542,9 @@ def grow_fragment(complex_pdb, fragment_pdb, core_atom, fragment_atom, iteration
     # Set box center from ligand COM
     resname_core = template_resnames[0]
     center = center_of_mass.center_of_mass(os.path.join(working_dir, c.PRE_WORKING_DIR, "{}.pdb".format(resname_core.upper())))
+    if force_field == "OFF":
+        if contrl == c.CONTROL_TEMPLATE:
+            contrl = os.path.join(PackagePath, "Templates/control_off.conf")
     if cov_res:
         if contrl == c.CONTROL_TEMPLATE:
             contrl = os.path.join(PackagePath, "Templates/control_covalent.conf")

--- a/frag_pele/main.py
+++ b/frag_pele/main.py
@@ -106,6 +106,9 @@ def parse_arguments():
                         help="Lamnda value to start the growing of a fragment from. F.ex: if you"
                              " set a 9 GS simulation, setting this value to 0.3 your fragment "
                              "growing will start from the third step, but second GS. (30% of the size and FFp).")
+    parser.add_argument("--keep_templates", action="store_true", help="If set, templates will not be overwritten "
+                                                                      " in templates_generated folder.")
+                                                                           
 
     # Plop related arguments
     parser.add_argument("-pl", "--plop_path", default=c.PLOP_PATH,
@@ -264,7 +267,7 @@ def parse_arguments():
            args.radius_box, args.sampling_control, args.data, args.documents, args.only_prepare, args.only_grow, \
            args.no_check, args.debug, args.highthroughput, args.test, args.cov_res, args.dist_const, \
            args.constraint_core, args.dih_constr, args.protocol, args.st_from, args.min_grow, args.min_sampling, \
-           args.force_field, args.dihedrals_list, args.srun
+           args.force_field, args.dihedrals_list, args.srun, args.keep_templates
 
 
 def grow_fragment(complex_pdb, fragment_pdb, core_atom, fragment_atom, iterations, criteria, plop_path, sch_path,
@@ -276,7 +279,7 @@ def grow_fragment(complex_pdb, fragment_pdb, core_atom, fragment_atom, iteration
                   radius_box=4, sampling_control=None, data=None, documents=None, only_prepare=False, only_grow=False, 
                   no_check=False, debug=False, cov_res=None, dist_constraint=None, constraint_core=None,
                   dih_constr=None, growing_protocol="SoftcoreLike", start_growing_from=0.0, min_grow=0.01, min_sampling=0.1,
-                  force_field='OPLS2005', dih_to_constraint=None, srun=True):
+                  force_field='OPLS2005', dih_to_constraint=None, srun=True, keep_templates=False):
 
 
     """
@@ -475,16 +478,17 @@ def grow_fragment(complex_pdb, fragment_pdb, core_atom, fragment_atom, iteration
                 aa_type = template_name
             else:
                 aa_type = None
-            create_templates.get_datalocal(pdb=os.path.join(working_dir,
-                                                 add_fragment_from_pdbs.c.PRE_WORKING_DIR,
-                                                 pdb_to_template), 
-                                           outdir=working_dir, 
-                                           forcefield=force_field, 
-                                           template_name=template_name, 
-                                           aminoacid=cov_res,
-                                           rot_res=rotamers,
-                                           aminoacid_type=aa_type,
-                                           sch_path = sch_path)
+            if not keep_templates:
+                create_templates.get_datalocal(pdb=os.path.join(working_dir,
+                                               add_fragment_from_pdbs.c.PRE_WORKING_DIR,
+                                               pdb_to_template), 
+                                               outdir=working_dir, 
+                                               forcefield=force_field, 
+                                               template_name=template_name, 
+                                               aminoacid=cov_res,
+                                               rot_res=rotamers,
+                                               aminoacid_type=aa_type,
+                                               sch_path = sch_path)
         if restart:
             if cov_res:
                 template_name = 'grw'
@@ -833,13 +837,21 @@ def grow_fragment(complex_pdb, fragment_pdb, core_atom, fragment_atom, iteration
     return fragment_names_dict
     
 
-def main(complex_pdb, serie_file, iterations=c.GROWING_STEPS, criteria=c.SELECTION_CRITERIA, plop_path=c.PLOP_PATH, sch_path=c.SCHRODINGER, pele_dir=c.PATH_TO_PELE, contrl=c.CONTROL_TEMPLATE, license=c.PATH_TO_LICENSE, resfold=c.RESULTS_FOLDER, 
-    report=c.REPORT_NAME, traject=c.TRAJECTORY_NAME, pdbout=c.PDBS_OUTPUT_FOLDER, cpus=c.CPUS, distcont=c.DISTANCE_COUNTER, threshold=c.CONTACT_THRESHOLD, epsilon=c.EPSILON, condition=c.CONDITION, metricweights=c.METRICS_WEIGHTS, 
-    nclusters=c.NUM_CLUSTERS, pele_eq_steps=c.PELE_EQ_STEPS, restart=False, min_overlap=c.MIN_OVERLAP, max_overlap=c.MAX_OVERLAP,
-    c_chain="L", f_chain="L", steps=c.STEPS, temperature=c.TEMPERATURE, seed=c.SEED, rotamers=c.ROTRES, banned=c.BANNED_DIHEDRALS_ATOMS, limit=c.BANNED_ANGLE_THRESHOLD, mae=False,
-    rename=None, threshold_clash=None, steering=c.STEERING, translation_high=c.TRANSLATION_HIGH, rotation_high=c.ROTATION_HIGH, 
-    translation_low=c.TRANSLATION_LOW, rotation_low=c.ROTATION_LOW, explorative=False, radius_box=c.RADIUS_BOX, sampling_control=None, data=c.PATH_TO_PELE_DATA, documents=c.PATH_TO_PELE_DOCUMENTS, 
-    only_prepare=False, only_grow=False, no_check=False, debug=False, protocol=False, test=False, cov_res=None, dist_constraint=None, constraint_core=False, dih_constr=None, growing_protocol="SoftcoreLike", start_growing_from=0.0, min_grow=0.01, min_sampling=0.1, force_field='OPLS2005', dih_to_constraint=None, srun=True):
+def main(complex_pdb, serie_file, iterations=c.GROWING_STEPS, criteria=c.SELECTION_CRITERIA, plop_path=c.PLOP_PATH, 
+         sch_path=c.SCHRODINGER, pele_dir=c.PATH_TO_PELE, contrl=c.CONTROL_TEMPLATE, license=c.PATH_TO_LICENSE, 
+         resfold=c.RESULTS_FOLDER, report=c.REPORT_NAME, traject=c.TRAJECTORY_NAME, pdbout=c.PDBS_OUTPUT_FOLDER, 
+         cpus=c.CPUS, distcont=c.DISTANCE_COUNTER, threshold=c.CONTACT_THRESHOLD, epsilon=c.EPSILON, 
+         condition=c.CONDITION, metricweights=c.METRICS_WEIGHTS, nclusters=c.NUM_CLUSTERS, 
+         pele_eq_steps=c.PELE_EQ_STEPS, restart=False, min_overlap=c.MIN_OVERLAP, max_overlap=c.MAX_OVERLAP,
+         c_chain="L", f_chain="L", steps=c.STEPS, temperature=c.TEMPERATURE, seed=c.SEED, rotamers=c.ROTRES, 
+         banned=c.BANNED_DIHEDRALS_ATOMS, limit=c.BANNED_ANGLE_THRESHOLD, mae=False,
+         rename=None, threshold_clash=None, steering=c.STEERING, translation_high=c.TRANSLATION_HIGH, 
+         rotation_high=c.ROTATION_HIGH, translation_low=c.TRANSLATION_LOW, rotation_low=c.ROTATION_LOW, 
+         explorative=False, radius_box=c.RADIUS_BOX, sampling_control=None, data=c.PATH_TO_PELE_DATA, 
+         documents=c.PATH_TO_PELE_DOCUMENTS, only_prepare=False, only_grow=False, no_check=False, debug=False, 
+         protocol=False, test=False, cov_res=None, dist_constraint=None, constraint_core=False, dih_constr=None, 
+         growing_protocol="SoftcoreLike", start_growing_from=0.0, min_grow=0.01, min_sampling=0.1, 
+         force_field='OPLS2005', dih_to_constraint=None, srun=True, keep_templates=False):
 
     if protocol == "HT":
         iteration = 1
@@ -931,7 +943,7 @@ def main(complex_pdb, serie_file, iterations=c.GROWING_STEPS, criteria=c.SELECTI
                                    translation_low, rotation_low, explorative, radius_box, sampling_control, data, documents,
                                    only_prepare, only_grow, no_check, debug, cov_res, dist_constraint, constraint_core,
                                    dih_constr, growing_protocol, start_growing_from, min_grow, min_sampling, force_field,
-                                   dih_to_constraint, srun)
+                                   dih_to_constraint, srun, keep_templates)
 
                     atomname_mappig.append(atomname_map)
  
@@ -970,7 +982,8 @@ def main(complex_pdb, serie_file, iterations=c.GROWING_STEPS, criteria=c.SELECTI
                      threshold_clash, steering, translation_high, rotation_high,
                      translation_low, rotation_low, explorative, radius_box, sampling_control, data, documents,
                      only_prepare, only_grow, no_check, debug, cov_res, dist_constraint, constraint_core, dih_constr,
-                     growing_protocol, start_growing_from, min_grow, min_sampling, force_field, dih_to_constraint, srun)
+                     growing_protocol, start_growing_from, min_grow, min_sampling, force_field, dih_to_constraint, srun,
+                     keep_templates)
             except Exception:
                 os.chdir(original_dir)
                 traceback.print_exc()
@@ -985,14 +998,16 @@ if __name__ == '__main__':
     rename, threshold_clash, steering, translation_high, rotation_high, \
     translation_low, rotation_low, explorative, radius_box, sampling_control, data, documents, \
     only_prepare, only_grow, no_check, debug, protocol, test, cov_res, dist_constraint, constraint_core, \
-    dih_constr, protocol, start_growing_from, min_grow, min_sampling, force_field, dih_to_constraint, srun = parse_arguments()
+    dih_constr, protocol, start_growing_from, min_grow, min_sampling, force_field, dih_to_constraint, srun, \
+    keep_templates = parse_arguments()
     
     main(complex_pdb, serie_file, iterations, criteria, plop_path, sch_path, pele_dir, contrl, license, resfold,
-             report, traject, pdbout, cpus, distcont, threshold, epsilon, condition, metricweights,
-             nclusters, pele_eq_steps, restart, min_overlap, max_overlap,
-             c_chain, f_chain, steps, temperature, seed, rotamers, banned, limit, mae,
-             rename, threshold_clash, steering, translation_high, rotation_high,
-             translation_low, rotation_low, explorative, radius_box, sampling_control, data, documents,
-             only_prepare, only_grow, no_check, debug, protocol, test, cov_res, dist_constraint, constraint_core,
-             dih_constr, protocol, start_growing_from, min_grow, min_sampling, force_field, dih_to_constraint, srun)
+         report, traject, pdbout, cpus, distcont, threshold, epsilon, condition, metricweights,
+         nclusters, pele_eq_steps, restart, min_overlap, max_overlap,
+         c_chain, f_chain, steps, temperature, seed, rotamers, banned, limit, mae,
+         rename, threshold_clash, steering, translation_high, rotation_high,
+         translation_low, rotation_low, explorative, radius_box, sampling_control, data, documents,
+         only_prepare, only_grow, no_check, debug, protocol, test, cov_res, dist_constraint, constraint_core,
+         dih_constr, protocol, start_growing_from, min_grow, min_sampling, force_field, dih_to_constraint, srun,
+         keep_templates)
 

--- a/tests/control_cov_test.conf
+++ b/tests/control_cov_test.conf
@@ -34,9 +34,7 @@ $CONSTRAINTS
                    "sideChainsToPerturb": { "links": {"ids": ["$RESCHAIN:$RESNUM"] } },
                       "parameters":{                                      
                              "overlapFactor": $OVERLAP,                        
-                             "numberOfStericTrials": 1,                  
                              "numberOfTrials": 1,                        
-                             "gridResolution": 10,                        
                              "atLeastOneSelectedTrial": true,
                              "maxTrialsForAtLeastOne": 1,
                              "refinementAngle": 10              

--- a/tests/control_cov_test.conf
+++ b/tests/control_cov_test.conf
@@ -4,7 +4,7 @@
   "verboseMode": false, 
   "Initialization" : {
      "allowMissingTerminals" :true,
-     "ForceField" : "OPLS2005",
+     "ForceField" : "$FF",
      "MultipleComplex" : [ $PDB ],
      "Solvent" : { "ionicStrength" : 0.15, "solventType" : "VDGBNP", "useDebyeLength" : true }
    },
@@ -25,7 +25,7 @@
                 "sideChainPredictionRegionRadius" : 6,
                 "perturbationCOMConstraintConstant" : 0.0,
                 "activateProximityDetection": true,
-                "temperature": $TEMPERATURE,
+                "temperature": 10000,
                 "numberOfPeleSteps": $STEPS
          },
 
@@ -34,11 +34,11 @@ $CONSTRAINTS
                    "sideChainsToPerturb": { "links": {"ids": ["$RESCHAIN:$RESNUM"] } },
                       "parameters":{                                      
                              "overlapFactor": $OVERLAP,                        
-                             "numberOfStericTrials": 20,                  
-                             "numberOfTrials": 10,                        
+                             "numberOfStericTrials": 1,                  
+                             "numberOfTrials": 1,                        
                              "gridResolution": 10,                        
                              "atLeastOneSelectedTrial": true,
-                             "maxTrialsForAtLeastOne": 50,
+                             "maxTrialsForAtLeastOne": 1,
                              "refinementAngle": 10              
                        }                                                  
                   },

--- a/tests/run_pytest
+++ b/tests/run_pytest
@@ -10,7 +10,7 @@ module purge
 unset PYTHONPATH
 export SCHRODINGER="/gpfs/projects/bsc72/SCHRODINGER_ACADEMIC"
 export PATH=/gpfs/projects/bsc72/conda_envs/FragPELE/v3.0.0/bin:$PATH
-export PYTHONPATH="/home/bsc72/bsc72292/projects/software/FragPELE/v3.0.0_beta/frag_pele"
+export PYTHONPATH="/gpfs/projects/bsc72/FragPELE/v3.1.0-beta/frag_pele"
 
 module load intel mkl impi gcc # 2> /dev/null
 module load impi


### PR DESCRIPTION
- Softcore protocol keeps charges constant in the scaffold for the first half of the growing steps.
- New flag **--keep_templates**. When set it does not create and overwrite both, the scaffold and full-ligand templates. 
- PELE paths updated to 1.7.1 in MN.
- Solvent OBC parameters automatically generated (to facilitate OpenFF simulations)
- **OFF** flag: OpenFF currently working when running PELE >=1.7.1